### PR TITLE
Fix references to old name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A tiny API Gateway based on [JWTs](https://jwt.io/).
 
-Netlify API can handle simple API proxying with signing for single page apps that already use JWTs for authentication.
+Gotiator can handle simple API proxying with signing for single page apps that already use JWTs for authentication.
 
-Netlify API Proxy is released under the [MIT License](LICENSE).
+Gotiator Proxy is released under the [MIT License](LICENSE).
 Please make sure you understand its [implications and guarantees](https://writing.kemitchell.com/2016/09/21/MIT-License-Line-by-Line.html).
 
 ## Installing

--- a/api/api.go
+++ b/api/api.go
@@ -41,8 +41,8 @@ var bearerRegexp = regexp.MustCompile(`^(?i)Bearer (\S+$)`)
 func (a *API) Version(w http.ResponseWriter, r *http.Request) {
 	sendJSON(w, 200, map[string]string{
 		"version":     a.version,
-		"name":        "Netlify API Proxy",
-		"description": "Netlify API Proxy is a dead simple API gateway",
+		"name":        "Gotiator",
+		"description": "Gotiator is a dead simple API gateway",
 	})
 }
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Config is the main configuration for Netlify API Proxy
+// Config is the main configuration for Gotiator
 type Configuration struct {
 	LogConf LoggingConfig `mapstructure:"log_conf"`
 	JWT     struct {

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/netlify/netlify-api-proxy
+package: github.com/netlify/gotiator
 import:
 - package: github.com/Sirupsen/logrus
   version: ~0.11.0


### PR DESCRIPTION
There were several references to the old name of the repository.
This change fixes them.

Signed-off-by: David Calavera <david.calavera@gmail.com>